### PR TITLE
Add a Dockerfile and documentation

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:latest
+
+# Install dependencies from apk package manager.
+RUN apk update && \
+    apk upgrade && \
+    apk --no-cache add python3 curl
+
+# Install python3, pip and urllib3 dependencies.
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python3 get-pip.py && \
+    pip install urllib3
+
+# Download the python script from github.
+RUN curl https://raw.githubusercontent.com/FairfieldTekLLC/HdHomeRunEpgXml/master/hdhomerun.py -o hdhomerun.py
+
+# Expose the command.
+CMD python3 hdhomerun.py > /dev/null 2>&1 ; cat /hdhomerun.xml

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ By default, the program will download **Two Weeks** of programming.
 
 **Note:**  It is recommended that you schedule the download of the EPG only ONCE per day, plex will read the TVXML file during maintenance in the middle of the night.  On Linux, use crontab -e to schedule, and for windows use the System Task Scheduler.
 
+## Running with Docker
+
+This repository includes a Dockerfile that will build an Alpine Linux Docker image that includes all the dependencies to run the `hdhomerun.py` script to generate the hdhomerun.xml file.
+
+Steps to use:
+
+* Make sure you have docker installed and available in your `$PATH`.
+* Download the `Dockerfile` file in the ./Docker to an empty directory.
+* Change into the new directory with the Dockerfile in it.
+* Run `docker build -t hdhomerunepgxml .` (don't miss the ".")
+* Run `docker run --rm hdhomerunepgxml > /[directory]/hdhomerun.xml` where [directory] is the place you want the file stored.
+You can schedule the docker run command above as a cronjob.
+
 
 
 


### PR DESCRIPTION
Thank you for creating this!

This PR includes a Docker file with all the dependencies required to run the `hdhomerun.py` file and pipe it to any file without having to install them on your local machine. 

My use case is that I have all of my local services running as docker containers so that I don't have to worry about mixed dependencies on the host OS. 